### PR TITLE
READMEs: Add syntax highlighting and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ support IDEs).
 For details of how to log into an ARCHER2 account, see https://docs.archer2.ac.uk/quick-start/quickstart-users/
 
 Check out the git repository to your laptop or ARCHER2 account.
-```
+```bash
 $ git clone https://github.com/ARCHER2-HPC/archer2-fortran-intro.git
 $ cd archer2-fortran-intro
 ```
 The default Fortran compiler on ARCHER2 is the Cray Fortran compiler
 invoked using `ftn`. For example,
-```
+```bash
 $ cd section1.01
 $ ftn example1.f90
 ```

--- a/section1.01/README.md
+++ b/section1.01/README.md
@@ -3,7 +3,7 @@
 ## First example
 
 A very simple program might be:
-```
+```fortran
 program example1
 
   ! An example program prints "Hello World" to the screen
@@ -51,7 +51,7 @@ We will return to the `contains` statement in the context of modules.
 ## `print` statement
 
 In general
-```
+```fortran
   print format [ , output-item-list ]
 ```
 where the `format` is a format specifier (discussed later) and the
@@ -65,7 +65,7 @@ is allowed to apply a default format for a given type of item.
 ## Alternative
 
 Consider the following program (available as `example3.f90`):
-```
+```fortran
 program example3
 
   use iso_fortran_env, only : output_unit
@@ -114,7 +114,7 @@ where the `io-unit` is a valid integer unit number, and the `format`
 is a format-specifier (as for `print`).
 
 Examples are
-```
+```fortran
   write (unit = output_unit, fmt = *)
   write (output_unit, *)
   write (*, *)
@@ -132,7 +132,7 @@ detail in the context of i/o to external files.
 Modern Fortran is not case sensitive. Older versions required capitals,
 a style which has persisted to the present day in some places. So you
 may see things such as
-```
+```fortran
 PROGRAM example1
 
   PRINT *, "Hello World"

--- a/section1.01/README.md
+++ b/section1.01/README.md
@@ -17,7 +17,7 @@ Formally, a Fortran program consists of one or more lines made up of
 Fortran _statements_. Line breaks are significant (e.g., there are
 no semi-colons `;` required here).
 
-Comments are introduced with an exclaimation mark `!`, and may trail
+Comments are introduced with an exclamation mark `!`, and may trail
 other statements.
 
 The `program` statement is roughly doing the equivalent job of `main()`
@@ -32,7 +32,7 @@ Check now you can compile and run the first example program `example1.f90`.
 ```
   [ program [program-name] ]
      [ specification-part ]
-     [ exectuable-part ]
+     [ executable-part ]
   [ contains
      internal-subprogram-part ]
   end [program-name]

--- a/section1.02/README.md
+++ b/section1.02/README.md
@@ -224,7 +224,7 @@ for complex conjugate.
 Broadly, assignments featuring different data types will cause
 promotion to a "wider" type or cause truncation to a "narrower" type.
 If one wants to be explicit, the equivalent of the cast mechanism in C
-is via intrisic functions, e.g.,
+is via intrinsic functions, e.g.,
 ```fortran
    integer          :: i = 1
    complex (real64) :: z = (1.0, 1.0)

--- a/section1.02/README.md
+++ b/section1.02/README.md
@@ -7,7 +7,7 @@ Fortran provides the following intrinsic data types: numeric types `integer`,
 
 The following program declares a variable with each of the three intrinsic
 numeric types, and provides an initial value in each case.
-```
+```fortran
 program example1
 
    implicit none
@@ -36,7 +36,7 @@ Other special characters recognised by Fortran are given in
 
 The `implicit` statement defines a type for variable names not explicitly
 declared.  So, the default situation can be represented by
-```
+```fortran
   implicit integer (i-n), real (a-h, o-z)
 ```
 that is, variables with names beginning with letters `i-n` are implicitly
@@ -66,7 +66,7 @@ The declarations above give us variables of some (implementation-defined)
 default type (typically 4-byte integers, 4-byte reals). A mechanism to
 control the exact kind, or representation,  is provided. For example
 (see `example2.f90`),
-```
+```fortran
   use iso_fortran_env, only : int64, real64
   implicit none
 
@@ -99,7 +99,7 @@ The optional _kind selector_ is
 The upshot of this is that the syntax of declarations is quite elastic,
 and you may see a number of different styles. A reasonable form of
 concise declaration with an explicit kind type parameter is:
-```
+```fortran
   integer (int32)  :: i
   real    (real32) :: a
   complex (real32) :: z
@@ -115,14 +115,14 @@ print out their values to the screen.
 
 One may (optionally) specify the kind of an integer literal by appending the
 kind type parameter with an underscore `_`, e.g.:
-```
+```fortran
 123
 +123
 -123
 12345678910_int64
 ```
 Floating point literal constants can take a number of forms. Examples are:
-```
+```fortran
 -3.14
 .314
 1.0e0             ! default precision
@@ -134,7 +134,7 @@ Floating point literal constants can take a number of forms. Examples are:
 
 Complex literals are constructed with real and imaginary parts, with each
 part real.
-```
+```fortran
 (0.0, 1.0)        ! square root of -1
 ```
 
@@ -142,7 +142,7 @@ part real.
 
 Suppose we did not want to hardwire our kind type parameters throughout
 the code. Consider:
-```
+```fortran
 program example3
 
   implicit none
@@ -174,7 +174,7 @@ It is an intrinsic function and part of the language itself.
 
 Using a parameter provides a degree of abstraction for the real data type.
 Other examples might include:
-```
+```fortran
   integer, parameter :: nmax = 32              ! A constant
   real,    parameter :: pi = 4.0*atan(1.e0)    ! A well-known constant
   complex, parameter :: zi = (0.0, 1.0)        ! square root of -1
@@ -190,7 +190,7 @@ another intrinsic function `storage_size()` (roughly equiavalent to C
 Run the program and check the actual values of the kind type parameters
 and associated storage sizes. Speculate on the portability of a program
 declaring, e.g.,:
-```
+```fortran
   integer (4) :: i32
   integer (8) :: i64
 ```
@@ -210,7 +210,7 @@ negation (`-`).
 
 In order of increasing precedence these are `-`, `+`, `/`, `*`,
 and `**` (otherwise left-to-right). In particular
-```
+```fortran
    a = b*c**2    ! is evaluated as b*(c**2)
    a = b*c*d     ! evaluated left-to-right (b*c)*d
 ```
@@ -225,7 +225,7 @@ Broadly, assignments featuring different data types will cause
 promotion to a "wider" type or cause truncation to a "narrower" type.
 If one wants to be explicit, the equivalent of the cast mechanism in C
 is via intrisic functions, e.g.,
-```
+```fortran
    integer          :: i = 1
    complex (real64) :: z = (1.0, 1.0)
    real    (real64) :: a, b
@@ -250,7 +250,7 @@ context.
 ### Complex real and imaginary parts
 
 The real and imaginary parts of a complex variable may be accessed
-```
+```fortran
   complex :: z
 
   z%re = 0.0     ! real part

--- a/section1.03/README.md
+++ b/section1.03/README.md
@@ -7,7 +7,7 @@ Fortran provides two non-numeric intrinsic data types: `logical` and
 
 Fortran has a `logical` type (cf. Boolean type in C); there are two relevant
 literal values, illustrated here:
-```
+```fortran
   logical :: switch0 = .false.
   logical :: switch1 = .true.
 ```
@@ -20,7 +20,7 @@ don't see it very often. The default `logical` kind has kind type parameter
 
 Standard logical operators `.or.`, `.and.` and `.not.` are available. The
 precedence is illustrated by, e.g.,
-```
+```fortran
   q = i .or. j .and. .not. k    ! evaluated as i .or. (j .and. (.not. k))
 ```
 Again, use parentheses to avoid ambiguity, or to add clarity.
@@ -65,7 +65,7 @@ Conditional statements are provided by the `if` construct, formally:
 ```
 There may be zero or more `else if` blocks, but at most one `else` block.
 At most one block is executed. For example (see `example1.f90`):
-```
+```fortran
   if (i < j) then
     print *, "The smaller is: i ", i
   else if (i > j) then
@@ -75,7 +75,7 @@ At most one block is executed. For example (see `example1.f90`):
   end if
 ```
 A single clause `if` statement is also available, for example:
-```
+```fortran
   if (a >= 0.0) b = sqrt(a)
 ```
 
@@ -90,14 +90,14 @@ A `if` construct with a name must have the matching name with the
 `end if`.
 
 For example
-```
+```fortran
 highly_nested_if_construct: if (a < b) then
                               ! ... structured block ...
                             end if highly_nested_if_construct
 ```
 As a matter of style, a leading name can be obtrusive, so one can put
 it on a separate line using the continuation character `&`, e.g.,
-```
+```fortran
 outer_if: &
   if (a < b) then
      ! ... structured block ...
@@ -130,7 +130,7 @@ expression. The _case-value-range-list_ is a comma-separated list of
 either individual values, or ranges.
 
 For example:
-```
+```fortran
    integer :: mycard = 1         ! Playing cards 1--13
 
    select case (mycard)
@@ -151,7 +151,7 @@ statement as in the C switch; only the relevant case block is executed.
 ## Character variables
 
 Character variables hold zero or more characters. Some examples are:
-```
+```fortran
 program example2
 
   implciit none
@@ -187,7 +187,7 @@ short?
 
 Write a program which uses real data types to compute the two solutions
 to the quadratic equation:
-```
+```fortran
    a*x**2 + b*x + c = 0
 ```
 for given values of `a`, `b`, and `c`.

--- a/section1.03/README.md
+++ b/section1.03/README.md
@@ -103,7 +103,7 @@ outer_if: &
      ! ... structured block ...
   endif outer_if
 ```
-The standand maximum line length in Fortran is 132 characters. Longer lines can
+The standard maximum line length in Fortran is 132 characters. Longer lines can
 be broken with the continuation character `&` to a maximum of 255 continuation
 lines (F2003).
 
@@ -154,7 +154,7 @@ Character variables hold zero or more characters. Some examples are:
 ```fortran
 program example2
 
-  implciit none
+  implicit none
   character (len = *), parameter :: string1 = "don't"   ! 5 characters
   character (len = 5)            :: string2 = "Don""t"  ! 5 characters
   character (len = 6)            :: string3 = 'don''t'  ! 5 characters + blank
@@ -163,8 +163,8 @@ end program example2
 ```
 The implementation must provide at least one type of character storage,
 with the default kind being `kind('A')`. In practice, kind type
-parameters are not often specifiied. However, there should be a `len`
-specifer.
+parameters are not often specified. However, there should be a `len`
+specifier.
 
 There is, again, a certain elasticity in the form of the declaration, so
 you may see slightly different things.

--- a/section2.01/README.md
+++ b/section2.01/README.md
@@ -6,13 +6,13 @@ C `for` construct). There is no equivalent of the C++ iterator class.
 ## Uncontroled `do` construct
 
 A simple iteration is provided by the `do` statement. For example, ...
-```
+```fortran
   do
     ! ... go around for ever ...
   end do
 ```
 A slightly more useful version requires some control (see `example1.f90`):
-```
+```fortran
    integer :: i = 0
    do
      i = i + 1
@@ -24,7 +24,7 @@ A slightly more useful version requires some control (see `example1.f90`):
    ! ... control continues here after exit ...
 ```
 Loop constructs may be nested, and may also be named (see `example2.f90`):
-```
+```fortran
   some_outer_loop: &
   do
     some_inner_loop: &
@@ -42,7 +42,7 @@ they belong to the innermost construct in which they appear.
 
 More typically, one encounters controlled iterations with an `integer`
 loop control variable. E.g.,
-```
+```fortran
   integer :: i
   do i = 1, 10, 2
     ! ... perform some computation ...
@@ -69,7 +69,7 @@ present, it will be 1 (unity); if the stride is present, it may not be zero.
 ### Exercise (2 minutes)
 
 What is the number of iterations in the following cases?
-```
+```fortran
    do i = 1, 10
      print *, "i is  ", i
    end do

--- a/section2.01/README.md
+++ b/section2.01/README.md
@@ -3,7 +3,7 @@
 Iteration in Fortran is based around the `do` construct (somewhat analogous to
 C `for` construct). There is no equivalent of the C++ iterator class.
 
-## Uncontroled `do` construct
+## Uncontrolled `do` construct
 
 A simple iteration is provided by the `do` statement. For example, ...
 ```fortran

--- a/section2.02/README.md
+++ b/section2.02/README.md
@@ -6,7 +6,7 @@ which are an intrinsic feature of the language.
 ## A one-dimensional array
 
 Arrays may be declared with addition of the `dimension` attribute, e.g.,
-```
+```fortran
 program example1
 
   implicit none
@@ -20,7 +20,7 @@ The default _lower bound_ is 1 and the _upper bound_ is 3.
 
 
 ### Lower and upper bounds
-```
+```fortran
   real, dimension(-2:1) :: b ! elements b(-2), b(1), b(0), b(1)
 ```
 Here we specify, explicitly, the lower and upper bounds. The
@@ -30,13 +30,13 @@ _size_ of this array is 4.
 ### Array constructor
 
 One may specify array values as a constructor
-```
+```fortran
   integer, dimension(3), parameter :: s = (/ -1, 0, +1 /)   ! F2003 or
   integer, dimension(3), parameter :: t = [  -1, 0, +1 ]    ! F2008
 ```
 
 ## A two-dimensional array
-```
+```fortran
   real, dimension(2,3) :: a   ! elements a(1,1), a(1,2), a(1,3)
                               !          a(2,1), a(2,2), a(2,3)
 ```
@@ -49,7 +49,7 @@ There is an array element order which in which we expect the implementation
 to store contiguously in memory. In Fortran this has be left-most
 dimension counting fastest. For array `a` we expect the order in
 memory to be
-```
+```fortran
 a(1,1), a(2,1), a(1,2), a(2,2), a(1,3), a(2,3)
 ```
 that is, the opposite the the convention in C.
@@ -57,7 +57,7 @@ that is, the opposite the the convention in C.
 ### `reshape`
 
 A constructor for an array of rank 2 or above might be used, e.g.,
-```
+```fortran
   integer, dimension(2,3) :: m = reshape([1,2,3,4,5,6], shape = [2,3])
 ```
 where we have used the intrinsic function `reshape()`.
@@ -72,7 +72,7 @@ available to interrogate array size and shape at run time.
 
 If we wish to establish storage with shape determined at run time,
 the _allocatable_ attribute can be used. The rank must be specified:
-```
+```fortran
   real, dimension(:, :), allocatable :: a
 
   ! ... establish shape required, say (imax, jmax) ...
@@ -102,7 +102,7 @@ value of zero to the argument.
 An array declared with the _allocatable_ attribute is initially in
 an unallocated state. When allocated, this status will change; this
 status can be interrogated via the intrinsic function `allocated()`.
-```
+```fortran
   integer, dimension(:), allocatable :: m
   ...
   if (allocated(m)) then

--- a/section2.02/README.md
+++ b/section2.02/README.md
@@ -46,7 +46,7 @@ dimension (_extent_ 3). It is said to have _shape_ (2,3), which is
 the sequence of extents in each dimension. Its size is 6 elements.
 
 There is an array element order which in which we expect the implementation
-to store contiguously in memory. In Fortran this has be left-most
+to store contiguously in memory. In Fortran this has to be the left-most
 dimension counting fastest. For array `a` we expect the order in
 memory to be
 ```fortran

--- a/section2.03/README.md
+++ b/section2.03/README.md
@@ -12,7 +12,7 @@ from the triplet
   [subscript] : [subscript] [: stride]
 ```
 Given a rank 1 array `a(:)`, some valid array sub-objects are:
-```
+```fortran
   a         ! the whole array
   a(:)      ! the whole array again
   a(1:4)    ! array section [ a(1), a(2), a(3), a(4) ]
@@ -26,7 +26,7 @@ it may not be zero.
 
 Intrinsic operations can be used to construct expressions which are
 arrays. For example:
-```
+```fortran
   integer, dimension(4, 8) :: a1, a2
   integer, dimension(4)    :: b1
 
@@ -41,14 +41,14 @@ the same shape (they are said to _conform_). A scalar conforms
 with an array of any shape.
 
 Given the above declarations, the following would not make sense:
-```
+```fortran
   b1 = a1
 ```
 
 ### Exercise (2 minutes)
 
 A caution. How should we interpret the following assignments?
-```
+```fortran
   d = 1.0
   e(:) = 1.0
 ```
@@ -62,7 +62,7 @@ argument will return a scalar, while a call with an array argument will
 return an array with the result of the function for each individual
 element of the argument.
 For example,
-```
+```fortran
    real, dimension(4) :: a, b
    ...
    b(1:4) = cos(a(1:4))
@@ -72,7 +72,7 @@ For example,
 
 Other intrinsic functions can be used to perform reduction operations
 on arrays, and usually return a scalar. Common reductions are
-```
+```fortran
    a = minval( [1.0, 2.0, 3.0] )
    b = maxval( [1.0, 2.0, 3.0] )
    c = sum(array(:))
@@ -81,7 +81,7 @@ on arrays, and usually return a scalar. Common reductions are
 ## Logical expressions and masks
 
 There is an array equivalent of the `if` construct, e.g.,:
-```
+```fortran
   real, dimension(20) :: a
   ...
   where (a(:) >= 0.0)
@@ -99,14 +99,14 @@ same shape.
 
 Logical functions `any()`, `all()`, and others may be used to reduce
 logical arrays or array expressions:
-```
+```fortran
    if (any(a(:) < 0.0)) then
      ! ...
    end if
 ```
 Some intrinsic functions have an optional mask argument which can be used to
 restrict the operations to certain elements, e.g.,
-```
+```fortran
   b = min(array(:), mask = (array(:) > 0.0))     ! minimum +ve value
   n = count(array(:), mask = (array(:) > 0.0))   ! count number of +ve values
 ```

--- a/section3.01/README.md
+++ b/section3.01/README.md
@@ -7,7 +7,7 @@ definitions and operations, and make them available elsewhere.
 
 We have already used one _intrinsic module_ (`iso_fortran_env`); we
 can also write our own, e.g.,
-```
+```fortran
 module module1
 
   implicit none
@@ -26,7 +26,7 @@ end module module1
 ```
 We may now `use` the new module in other _program units_ (main program or
 other modules). For example:
-```
+```fortran
 program example1
 
   use module1
@@ -58,7 +58,7 @@ of which more later.
 
 One would typically expect modules and a main program to be in
 separate files, e.g.,:
-```
+```bash
 $ ls
 module1.f90     program1.f90
 ```
@@ -67,12 +67,12 @@ the corresponding file (with extension `.f90`). You can do
 differently, but it can become confusing. Likewise for the main program.
 
 We can compile the module, e.g.,
-```
+```bash
 $ ftn -c module1.f90
 ```
 where the `-c` option to the Fortran compiler `ftn` requests compilation
 only (no link). This should give us two new files:
-```
+```bash
 $ ls
 module1.f90     module1.mod     module1.o       program1.f90
 ```
@@ -85,7 +85,7 @@ executable.
 
 We can now compile both the main program and the module to give an
 executable.
-```
+```bash
 $ ftn module1.o program1.f90
 ```
 Again, by analogy with C header files, we do not include the `.mod`
@@ -98,11 +98,11 @@ working directory).
 If you haven't already done so, compile the accompanying `module1.f90`
 and `program1.f90`. Check the errors which occur if you: (1) try to
 compile the program without the module file via, e.g.,
-```
+```bash
 $ ftn program1.f90
-````
-and (2), if you try to compile and link the module file alone:
 ```
+and (2), if you try to compile and link the module file alone:
+```bash
 $ ftn module1.f90
 ```
 
@@ -112,10 +112,10 @@ $ ftn module1.f90
 Entities declared in a module are, by default, available by use association,
 that is, they are visible in program units which `use` the module. One can
 make this scope explicit via the `public` and `private` statements.
-```
+```fortran
 module module1
 
-  implciit none
+  implcit none
   public
 
   integer, parameter :: mykind = kind(1.d0)
@@ -135,7 +135,7 @@ _host association_ (always).
 
 An alternative would be to switch the default to `private`, and explicitly
 add `public` attributes:
-```
+```fortran
 module module1
 
   implicit none
@@ -170,7 +170,7 @@ check the error if you try to compile `program1.f90`.
 
 It is possible to establish non-parameter data in the specification
 section of a module. E.g.,
-```
+```fortran
 module module2
 
   implicit none
@@ -187,7 +187,7 @@ neither thread safe nor re-entrant.
 
 Even worse, variables declared with an initialisation in a module
 sub-program, e.g.,
-```
+```fortran
   integer :: i = 1
 ```
 implicitly take on the Fortran `save` attribute. This means the
@@ -212,7 +212,7 @@ of large routines.
 
 It is possible to introduce a local scope which follows executable
 statements using the `block` construct. Schematically:
-```
+```fortran
    ... some computation ...
    block
      integer :: itmp                  ! in scope within the block only
@@ -237,7 +237,7 @@ Check you can use the new function from a main program.
 What really needs to be publicly available from the module in this case?
 
 Additional exercise: Can we have the following situation:
-```
+```fortran
 module a
 
   use b
@@ -246,7 +246,7 @@ module a
 end module a
 ```
 and
-```
+```fortran
 module b
 
   use a

--- a/section3.01/README.md
+++ b/section3.01/README.md
@@ -115,7 +115,7 @@ make this scope explicit via the `public` and `private` statements.
 ```fortran
 module module1
 
-  implcit none
+  implicit none
   public
 
   integer, parameter :: mykind = kind(1.d0)
@@ -241,7 +241,7 @@ Additional exercise: Can we have the following situation:
 module a
 
   use b
-  implciit none
+  implicit none
   ! content a ...
 end module a
 ```

--- a/section3.02/README.md
+++ b/section3.02/README.md
@@ -10,13 +10,13 @@ part of the module file.
 The difference between functions and subroutines is to a degree one of
 context. A function returns a result and is generally used where it
 is best invoked as part of an expression or assignment, schematically:
-```
+```fortran
   value = my_function(arg1, arg2, ...)
 ```
 Unlike C, it is not possible simply to discard a function result.
 A subroutine, by contrast, does not return a result (it may be thought of as a
 `void` function in C terms), but it is also invoked differently:
-```
+```fortran
   call my_subroutine(arg1, arg2, ...)
 ```
 Subroutines are generally used to express more lengthy algorithms.
@@ -38,7 +38,7 @@ different cases can be identified:
 
 These three cases may be encoded in the declarations of the dummy
 arguments of a procedure via the `intent` attribute . For example:
-```
+```fortran
   subroutine print_x(x)
 
     real, intent(in) :: x
@@ -54,7 +54,7 @@ merely not reflected in the caller.
 
 If one wants to alter the existing value of the argument, `intent(inout)`
 is appropriate:
-```
+```fortran
   subroutine increment_x(x)
 
     real, intent(inout) :: x
@@ -65,7 +65,7 @@ is appropriate:
 ```
 If the dummy argument is undefined on entry, or has a value which is
 simply to be overwritten, use `intent(out)`, e.g.:
-```
+```fortran
   subroutine assign_x(x)
 
     real, intent(out) :: x
@@ -91,7 +91,7 @@ the intent of the dummy arguments in `module1.f90`.
 
 ## Functions
 A function may be defined as:
-```
+```fortran
 function my_mapping(value) result(a)
 
   real, intent(in) :: value
@@ -113,7 +113,7 @@ As ever, there is some elasticity in the exact form of the declarations
 you may see. In particular, older versions did not have the `result()`
 suffix, and the _function-name_ was used as the variable to which the
 return value was assigned. E.g.,
-```
+```fortran
 real function length(area)
   real area
   length = sqrt(area)
@@ -127,7 +127,7 @@ names to be decoupled.
 Procedures which have no side effects may be declared with the
 `pure` prefix; this may provide useful information to the compiler
 in some circumstances. E.g.,
-```
+```fortran
 pure function special_function(x) result(y)
   real, intent(in) :: x
   ! ...
@@ -145,7 +145,7 @@ There are a number of conditions which must be met to qualify for
 
 If recursion is required, a procedure must be declared with the
 `recursive` prefix. E.g.,
-```
+```fortran
 recursive function fibonacci(n) result(nf)
   ! ... implementation...
   nf = fibonacci(n-1) + fibonacci(n-2)

--- a/section3.02/README.md
+++ b/section3.02/README.md
@@ -1,6 +1,6 @@
 # Functions and subroutines
 
-Functions and subroutines, referred to colletively as _procedures_, may be
+Functions and subroutines, referred to collectively as _procedures_, may be
 defined as module sub-programs, where the compiler will automatically
 generate the contract block (aka. forward declaration, prototype) as
 part of the module file.

--- a/section3.03/README.md
+++ b/section3.03/README.md
@@ -41,7 +41,7 @@ actual arguments.
 ### `lbound()` and `ubound()` again
 
 The `lbound()` and `ubound()` functions return a rank one array which
-is the  relevant bound in each dimension. The optional argument `dim`
+is the relevant bound in each dimension. The optional argument `dim`
 can be used to obtain the bound in the corresponding rank or dimension
 e.g.,
 ```fortran

--- a/section3.03/README.md
+++ b/section3.03/README.md
@@ -9,7 +9,7 @@ are arrays.
 
 One is entitled to make explicit the shape of an array in a procedure
 definition, e.g.,
-```
+```fortran
   subroutine array_action1(nmax, a)
     integer, intent(in)                    :: nmax
     real, dimension(1:nmax), intent(inout) :: a
@@ -23,7 +23,7 @@ of the array is unspecified, it takes on the default value of `1`.
 ### Assumed shape
 However, it may be more desirable to leave the exact shape
 implicit in the array itself, e.g.,
-```
+```fortran
   subroutine array_action2(a, b)
     real, dimension(:,:), intent(in   ) :: a
     real, dimension(:,:), intent(inout) :: b
@@ -44,7 +44,7 @@ The `lbound()` and `ubound()` functions return a rank one array which
 is the  relevant bound in each dimension. The optional argument `dim`
 can be used to obtain the bound in the corresponding rank or dimension
 e.g.,
-```
+```fortran
   real, dimension(:,:), intent(in) :: a
   integer :: lb1, lb2
 
@@ -66,7 +66,7 @@ are available?
 
 One is allowed to bring into existence `automatic' arrays on the stack.
 These are usually related to temporary workspace, e.g.,
-```
+```fortran
 subroutine array_swap1(a, b)
   integer, dimension(:), intent(inout) :: a, b
   integer, dimension(size(a))          :: tmp
@@ -84,7 +84,7 @@ loop and a temporary scalar.
 
 It may occasionally be appropriate to have a dummy
 argument with both an intent and `allocatable` attribute.
-```
+```fortran
   subroutine my_storage(lb, ub, a)
 
     integer, intent(in) :: lb, ub
@@ -112,7 +112,7 @@ deallocated when the relevant expression has been evaluated.
 We have encountered a number of intrinsic procedures with optional dummy
 arguments. Such procedures may be constructed with the `optional`
 attribute for a dummy argument, e.g.:
-```
+```fortran
   subroutine do_something(a, flag, ierr)
     integer, intent(in)            :: a
     logical, intent(in),  optional :: flag
@@ -123,7 +123,7 @@ attribute for a dummy argument, e.g.:
 Any operations on such optional arguments should guard against the
 possibility that the corresponding actual argument was not present
 using the intrinsic function `present()`. E.g.,
-```
+```fortran
   local_flag = some_default_value
   if (present(flag)) local_flag = flag
 ```
@@ -139,7 +139,7 @@ Procedures will often have a combination of a number of mandatory
 (non-optional) dummy arguments, and optional arguments. These may be
 mixed via the use of keywords, which are the dummy argument name. E.g.,
 using the subroutine defined above:,
-```
+```fortran
   call do_something(a, ierr = my_error_var)
 ```
 Here, `a` is appearing as a conventional positional argument, while
@@ -156,7 +156,7 @@ Consider again the problem of the tri-diagonal matrix.
 
 Refactor your existing stand-alone program (or use the template
 `exercise.f90`) to provide a module subroutine such as
-```
+```fortran
   subroutine tridiagonal_solve(b, a, c, rhs, x)
 ```
 where `b`, `a`, and `c` are arrays of the relevant

--- a/section4.01/README.md
+++ b/section4.01/README.md
@@ -11,14 +11,14 @@ track of the length of the string.
 The meaning of relational operators `==` and so on in the context of
 characters is largely what one would expect from the standard ASCII
 sequence. E.g.,
-```
+```fortran
    "A" <  "b"      ! true
    "A" == "a"      ! false
    "A" /= "]"      ! true
 ```
 Note the ordinal position of a single character in the ASCII sequence
 can be found via an intrinsic function, e.g.:
-```
+```fortran
    integer             :: i
    character (len = 1) :: c
    i = iachar("A")           ! i = 65
@@ -38,20 +38,20 @@ function.
 The length with trailing blanks removed is `len_trim()`. To actually
 remove the trailing blanks, use `trim()`. This is often seen when
 concatenating fixed-length character strings:
-```
+```fortran
   print *, "File name: ", trim(file_stub)//"."//trim(extension)
 ```
 
 It's also useful if you want to perform an operation on each individual
 character, e.g.,
-```
+```fortran
   do n = 1, len_trim(string)
     if (string(n:n) == 'a') counta = counta + 1
   end do
 ```
 Note that the colon is mandatory in a sub-string reference, so a
 single character must be referenced, e.g.,
-```
+```fortran
    print *, "Character at position i: ", string(i:i)
 ```
 
@@ -62,7 +62,7 @@ justification, sub-string searches, and so on.
 
 The easiest way to provide a string which can be manipulated on a
 flexible basis is the deferred length character:
-```
+```fortran
   character (len = :), allocatable :: string
 
   string = "ABCD"         ! Allocate and assign string
@@ -77,7 +77,7 @@ trailing blanks.
 If an allocation is required for which only the length is known (e.g.,
 there is no literal string involved), the following form of allocation
 is required:
-```
+```fortran
   integer :: mylen
   character (len = :), allocatable :: string
 
@@ -88,7 +88,7 @@ is required:
 
 Allocatable strings will automatically be deallocated when they go out
 of scope and are no longer required. One can also be explicit:
-```
+```fortran
   deallocate(string)
 ```
 if wanted.
@@ -96,12 +96,12 @@ if wanted.
 ## Arrays of strings
 
 We have seen that we can define a fixed length parameter, e.g.,:
-```
+```fortran
   character (len = *), parameter :: day = "Sunday"
 ```
 Suppose we wanted an array of strings for "Sunday", "Monday", "Tuesday",
 and so on. One might be tempted to try something of the form:
-```
+```fortran
   character (len = *), dimension(7), parameter :: days = [ ... ]
 ```
 
@@ -112,7 +112,7 @@ Check the result of the compilation of `example3.f90`.
 The are a number of solutions to this issue. One could try to pad the
 lengths of each array element to be the same length. A better way is
 to use a constructor with a type specification:
-```
+```fortran
 [character (len = 9) :: "Sunday", "Monday", "Tuesday", "Wednesday", ...]
 ```
 Here the type specification is used to avoid ambiguity in how the
@@ -125,7 +125,7 @@ Check you can make this adjustment to `example3.f90`.
 
 If a character variable has intent `in` in the context of a procedure,
 it typically may be declared:
-```
+```fortran
   subroutine some_character_operation(carg1, ...)
 
      character (len = *), intent(in) :: arg1
@@ -136,12 +136,12 @@ where the length does not change.
 
 For all other cases, use of deferred length allocable characters is
 recommended. E.g.,
-```
+```fortran
   function build_filename(stub, extension) result(filename)
 
     character (len = *), intent(in)  :: stub
     character (len = *), intent(in)  :: extension
-    character (len = :), allocatable :: filenane
+    character (len = :), allocatable :: filename
     ...
 ```
 A matching declaration in the caller is required.

--- a/section4.02/README.md
+++ b/section4.02/README.md
@@ -22,7 +22,7 @@ must have only variables.
 The standard input unit (`input_unit` from `iso_fortran_env` in the above)
 is typically the keyboard (or "screen") for interactive use.
 
-## Format specifer
+## Format specifier
 
 In addition to the _list-directed_ or free-format `*` specifier, a
 format may be a string literal, a fixed character parameter, or a
@@ -34,7 +34,7 @@ string constructed at run time. Some examples are:
    write(unit = myunit) var    ! unformatted (no format)
 ```
 
-Output with string (or `*`) format specfier is referred to as _formatted_ I/O.
+Output with string (or `*`) format specifier is referred to as _formatted_ I/O.
 This is to distinguish it from _unformatted_ I/O; this is essentially a
 direct dump of the binary internal representation. For unformatted
 I/O the format specifier is simply omitted.
@@ -128,7 +128,7 @@ If a leading plus sign is wanted, use the `sp` control, e.g.:
 
 ### Exercise (2 minutes)
 
-Compile and run the accompanying `example1.f90`, which provides some specimin
+Compile and run the accompanying `example1.f90`, which provides some specimen
 formats. Some of the format specifiers have not allowed a large enough
 width. What's the result? What's the solution?
 
@@ -147,7 +147,7 @@ In this way, more complex formats can be constructed.
 ### Complex variables
 
 Variables of `complex` type are treated as two `real` values for the
-purposes of a format specifer. The real and imaginary part do not have to
+purposes of a format specifier. The real and imaginary part do not have to
 have the same edit descriptor.
 
 ### Logical variables

--- a/section4.02/README.md
+++ b/section4.02/README.md
@@ -9,7 +9,7 @@ tabulation of output for human readers.
 
 So far we have seen only output (via either `print` or `write`). Input
 is via the `read` statement.
-```
+```fortran
   use :: iso_fortran_env
   ...
   read (unit = input_unit, fmt = *) var-io-list
@@ -27,7 +27,7 @@ is typically the keyboard (or "screen") for interactive use.
 In addition to the _list-directed_ or free-format `*` specifier, a
 format may be a string literal, a fixed character parameter, or a
 string constructed at run time. Some examples are:
-```
+```fortran
    read (*, *) var             ! read using list-directed, or free format
    print '(a)', "A string"     ! character literal '(a)'
    write (*, myformat) var     ! character variable (or parameter)
@@ -60,7 +60,7 @@ some common examples of the three different types of descriptor.
 Data edit descriptors feature a single character describing the type
 data format wanted, and a literal integer part indicating the total
 field width, and number of decimals. These include
-```
+```fortran
   iw        ! integer width w characters
   fw.d      ! floating point number total width w and d decimal characters
   ew.d      ! scientific notation with total width w and d decimal characters
@@ -73,7 +73,7 @@ decimal point.
 
 Data edit descriptors should correspond to the relevant item in the _io-list_,
 based on position. Some simple examples are:
-```
+```fortran
   integer :: ivar = 40
   real    :: avar = 40.0
   print "(  i10)", ivar           ! produces "40" with 8 leading spaces
@@ -95,7 +95,7 @@ There will be an appropriate movement in the decimal point.
 
 If an exponent greater than 999 is required, an optional `e` descriptor for
 the exponent itself is available:
-```
+```fortran
   print "(e14.3e4)", avar         ! Use at least 4 digits in exponent
 ```
 
@@ -106,7 +106,7 @@ required.
 ### Character string edit descriptors
 
 One can use a string literal as part of the edit descriptor itself, e.g.,
-```
+```fortran
   real :: avar = 4.0
   print "('This is the result: ', e14.7)", avar
 ```
@@ -116,13 +116,13 @@ One can use a string literal as part of the edit descriptor itself, e.g.,
 There are a number of these. They do not correspond to an item in the
 _io-list_, but alter the appearance of the output. The most common is
 `x` which introduces a space (or blank). E.g.,
-```
+```fortran
    print "(i12,x,e12.6)", ivar, avar
 ```
 This will ensure at least on space between the two items in the list.
 
 If a leading plus sign is wanted, use the `sp` control, e.g.:
-```
+```fortran
   print "(sp,e12.6)", abs(avar)
 ```
 
@@ -137,7 +137,7 @@ width. What's the result? What's the solution?
 
 For a larger number of items of the same type, it can be useful to specify
 a _repeat count_. Simply prefix a literal integer count to the format, e.g.:
-```
+```fortran
    real, dimension(4) :: a = [ 1.0, 2.0, 3.0, 4.0]
 
    print "(4(2x,e14.7))", a(1:4)
@@ -160,7 +160,7 @@ may only produce an `F`.
 
 If no new line at all is wanted, one can use the `advance = no` argument
 to `write()`, e.g.:
-```
+```fortran
   write (*, "('Input an integer: ')", advance = 'no')
   read (*, *) ivar
 ```
@@ -169,7 +169,7 @@ Non-advancing output must not use list-directed I/O.
 ## Statement labels
 
 Formally, a format specifier may also be a _statement label_. For example,
-```
+```fortran
    write (unit = myunit, fmt = 100) ia, ib, c
 
 100 format(i3, i3, f14.7)

--- a/section4.03/README.md
+++ b/section4.03/README.md
@@ -78,7 +78,7 @@ a file exists:
 
 ## Internal files
 
-In some situations, it may be convient to use a formatted read to
+In some situations, it may be convenient to use a formatted read to
 generate a new string in memory (in the same way as `sprintf` in C).
 Fortran uses a so-called _internal file_, which is usually a
 character string. E.g.,

--- a/section4.03/README.md
+++ b/section4.03/README.md
@@ -8,7 +8,7 @@ part of a useful application.
 
 File handles, or _unit numbers_ are obtained using `open()`, and are
 used to direct the output of `write()` to the relevant file.
-```
+```fortran
   integer :: myunit
 
   open(newunit = myunit, file = 'filename.dat', form = 'formatted', &
@@ -20,7 +20,7 @@ used to direct the output of `write()` to the relevant file.
   close(unit = myunit, status = 'keep')
 ```
 To read back the same data, we might use:
-```
+```fortran
    open(newunit = myunit, file = 'filename.dat', form = 'formatted', &
         action = "read", status = "old")
 
@@ -71,7 +71,7 @@ The `inquire` statement offers a way to obtain information on the
 current state of either unit numbers or files. There are a large
 number of optional arguments. One common usage is to check whether
 a file exists:
-```
+```fortran
   logical :: exists
   inquire( file = 'filename.dat', exist = exists)
 ```
@@ -82,7 +82,7 @@ In some situations, it may be convient to use a formatted read to
 generate a new string in memory (in the same way as `sprintf` in C).
 Fortran uses a so-called _internal file_, which is usually a
 character string. E.g.,
-```
+```fortran
    character (len = 10) :: buffer
    integer              :: ival
    ...
@@ -98,7 +98,7 @@ formal exception mechanism in Fortran, some ability to recover is
 available.
 
 Consider the following schematic example:
-```
+```fortran
 subroutine read_my_file_format(myunit, ..., ierr)
 
   integer, intent(in)   :: myunit
@@ -133,7 +133,7 @@ statement with intent out `ierr = 0`.
 
 Both `open` and `close` statements provide optional arguments for
 error handling, illustrated schematically here with `open()`:
-```
+```fortran
   integer :: ierr
   character (len = 128) :: msg
 
@@ -153,7 +153,7 @@ truncated or padded appropriately.
 
 Error handling facilities for `read()` and `write()` are similar, and
 are illustrated here:
-```
+```fortran
   write (myunit, myformat, end = 999, err = 998, iostat = ierr, iomsg = msg) ..
 ```
 * `end`: label in same scope to which control is transferred on end-of-file;
@@ -163,7 +163,7 @@ are illustrated here:
 
 The two negative `iostat` cases can be distinguished via calls to
 the intrinsic functions
-```
+```fortran
   is_iostat_end(ierr)
   is_iostat_eor(ierr)
 ```
@@ -172,7 +172,7 @@ the intrinsic functions
 
 If one really can't continue, then execution can be terminated immediately
 via the `stop` statement. This has an optional message string argument.
-```
+```fortran
   stop "Cannot continue"
 ```
 In general one should try to recover by returning control to the caller,

--- a/section5.01/README.md
+++ b/section5.01/README.md
@@ -12,7 +12,7 @@ this introductory course will only touch on this feature.
 ## Type definitions
 
 A derived type with two _components_ would be declared, e.g.,
-```
+```fortran
   type :: my_type
     integer                         :: nmax
     real, dimension(:), allocatable :: data
@@ -22,11 +22,11 @@ Components may be intrinsic data types (all declared in the usual way),
 or derived types.
 
 A variable of this type is declared
-```
+```fortran
   type (my_type) :: var
 ```
 and individual components are referenced with the component selector `%`, e.g.,
-```
+```fortran
   var%nmax = 10
   ...
   print *, "Values are ", var%data(1:3)
@@ -36,7 +36,7 @@ intrinsic type.
 
 An array of types is defined in the usual way, and the component
 selector is applied to individual elements, e.g.,
-```
+```fortran
   type (my_type), dimension(10) :: var
   ...
   var(1)%nmax = 100
@@ -65,13 +65,13 @@ Formally, we have
 ```
 The default situation is for both the type and its components to
 be public. This may be made explicit by
-```
+```fortran
   type, public :: my_type
     ...
   end type my_type
 ```
 If one wants a public type with private components (an opaque type), use
-```
+```fortran
   type, public :: my_opaque_type
     private
     ...
@@ -88,7 +88,7 @@ then it can be declared `private` in the attribute list.
 
 For types with public components, it is possible to use a structure
 constructor to provide initialisation, e.g.,:
-```
+```fortran
   type, public :: my_type
      integer :: ia
      real    :: b
@@ -108,7 +108,7 @@ must appear as `null()` in a constructor expression list.
 
 A type may be defined with default initial values. One noatable exception
 is that allocatable components do not have an initialisation. E.g.:
-```
+```fortran
   type :: my_type
     integer                            :: nmax = 10
     real                               :: a0 = 1.0
@@ -116,7 +116,7 @@ is that allocatable components do not have an initialisation. E.g.:
   end type
 ```
 A default initialisation can be applied by using an empty constructor::
-```
+```fortran
   type (my_type) :: a
 
   a = my_type()
@@ -157,7 +157,7 @@ What would you then have to provide to allow initialisation?
 
 List-directed output for derived types can be used to provide a
 default output in which each component appears in order, schematically:
-```
+```fortran
   type (my_type) :: a
   ...
   write (*, fmt = *) a
@@ -175,14 +175,14 @@ A special `dt` editor descriptor exists, of the form:
   dt[iodesc-string][(v-list)]
 ```
 For example we may have
-```
+```fortran
   dt" my-type: "(2,14)
 ```
 The _iodesc-string_ and _v-list_ will re-appear as arguments to
 a special function which must be provided by the programmer.
 Information on this function is provided as part of the _procedure-part_
 of the type definition:
-```
+```fortran
 type, public :: my_type
   integer :: n
   complex :: z
@@ -192,7 +192,7 @@ contains
 end type my_type
 ```
 The following module subroutine should then be provided:
-```
+```fortran
   subroutine my_type_write_formatted(self, unit, iotype, vlist, iostat, iomsg)
 
     class (my_type),     intent(in)    :: self
@@ -239,7 +239,7 @@ can use your own version.
 
 Try implementing the generic `write(formatted)` function for the following
 type:
-```
+```fortran
   type, public :: my_date
     integer :: day = 1        ! day 1-31
     integer :: month = 1      ! month 1-12

--- a/section5.01/README.md
+++ b/section5.01/README.md
@@ -106,7 +106,7 @@ must appear as `null()` in a constructor expression list.
 
 ### Default initialisation
 
-A type may be defined with default initial values. One noatable exception
+A type may be defined with default initial values. One notable exception
 is that allocatable components do not have an initialisation. E.g.:
 ```fortran
   type :: my_type

--- a/section5.02/README.md
+++ b/section5.02/README.md
@@ -9,7 +9,7 @@ data structures.
 
 A pointer may be declared by adding the `pointer` attribute to
 the relevant data type, e.g.,
-```
+```fortran
 integer, pointer :: p => null()
 ```
 In this case we declare a pointer to integer `p`, which is initialised to
@@ -21,7 +21,7 @@ errors is to forget the `>` if pointer assignment is wanted.
 
 It is important to be able to check that a given pointer is not `null()`.
 This is done with the `associated()` intrinsic; schematically,
-```
+```fortran
    integer, pointer :: p => null()
    ...
    if (associated(p)) ... do something
@@ -31,7 +31,7 @@ way.
 
 If one wishes to have a pointer to an array, the rank of the pointer
 should be the same as the target:
-```
+```fortran
   real, dimension(:),   pointer :: p1
   real, dimension(:,:), pointer :: p2
 ```
@@ -42,7 +42,7 @@ and so on.
 
 A pointer may be associated with another variable of the appropriate
 type (which is not itself a pointer) by using the target attribute:
-```
+```fortran
   integer, target  :: datum
   integer, pointer :: p
 
@@ -51,7 +51,7 @@ type (which is not itself a pointer) by using the target attribute:
 The pointer is now said to be associated with the target. We can now
 perform operations on `datum` vicariously through `p`. E.g., a
 standard assignment would be
-```
+```fortran
   integer, target  :: datum = 1
   integer, pointer :: p
 
@@ -69,7 +69,7 @@ C `restrict` qualifier.
 Note that there is an optional _target_ argument to the `associated()`
 intrinsic, which allows the programmer to inquire whether a pointer
 is associated with a specific target, e.g.,
-```
+```fortran
    associated(p, target = datum)   ! .true. if p => datum
 ```
 
@@ -88,7 +88,7 @@ of `p` before and after the pointer assignment.
 One common use of pointers is to provide a temporary alias to another
 variable (where no copying takes place). As a convenience, one can
 use the `associate` construct, e.g.:
-```
+```fortran
   real :: improbably_or_tediously_long_variable_name
   ...
   associate(p => improbably_or_tediously_long_variable_name)
@@ -109,7 +109,7 @@ Compile, and check the output of the accompanying `example2.f90`.
 
 One common use of pointers is for linked data structures. For example,
 an entry in a linked list might be represented by the type
-```
+```fortran
   type :: my_node
     integer                 :: datum
     type (my_node), pointer :: next
@@ -119,7 +119,7 @@ This sort of dynamic data structure requires that we establish or
 destroy storage as entries are added to the list, or removed from
 the list.
 
-```
+```fortran
   subroutine my_list_add_node(head, datum)
 
     ! Insert new datum at head of list
@@ -156,12 +156,12 @@ recommended.
 If one needs to increase (or decrease) the size of an existing
 allocatable array, the `move_alloc()` intrinsic is useful. E.g.,
 if we have an integer rank one array
-```
+```fortran
   integer, dimension(:), allocatable :: iorig
 ```
 and establish storage of a given size, and some relevant initialisations,
 we may then wish to increase the size of it.
-```
+```fortran
   integer :: nold
   integer, dimension(:), allocatable :: itmp
 
@@ -178,12 +178,12 @@ original storage.
 ### Arrays of pointers
 
 A small trick is required to arrange an array of pointers. Recall that
-```
+```fortran
   real, dimension(:), pointer :: a
 ```
 is a pointer to a rank one array. If one wanted an array of such
 objects, it can be achieved by wrapping it in a type:
-```
+```fortran
   type :: pointer_rr1
     real, dimension(:), pointer :: p => null()
   end type pointer_rr1

--- a/section6.01/README.md
+++ b/section6.01/README.md
@@ -250,6 +250,6 @@ with the sum
 Write a procedure that will take the limits `a` and `b`, the integer number
 of steps `n`, and the function, and returns a result.
 
-To check, you can evaluation the function `cos(x) sin(x)` between `a = 0`
+To check, you can evaluate the function `cos(x) sin(x)` between `a = 0`
 and `b = pi/2` (the answer should be 1/2). Check your answer gets better
 for value of `n = 10, 100, 1000`.

--- a/section6.01/README.md
+++ b/section6.01/README.md
@@ -13,7 +13,7 @@ information about the interface.
 
 Consider a program unit (which may or may not be a separate file) which
 contains a function declaration outside a module scope. E.g.,
-```
+```fortran
   function my_mapping(i) result(imap)
     integer, intent(in) :: i
     integer             :: imap
@@ -27,7 +27,7 @@ about the function.
 It is possible to provide the compiler with some limited information
 about the return value of the function with the `external` attribute
 (also available as a statement). E.g.,
-```
+```fortran
   program example
 
     implicit none
@@ -38,7 +38,7 @@ about the return value of the function with the `external` attribute
 However, we have still not given the compiler full information about
 the interface. The interface is said to remain _implicit_. To make
 it explicit, the `interface` construct is available:
-```
+```fortran
   program example
 
     implicit none
@@ -67,14 +67,14 @@ defined in the file `external.f90`, and an accompanying program
 `example1.f90` calls the function therein.
 
 Compile the two files, e.g.:
-```
+```bash
 $ ftn external.f90 program.f90
 ```
 (note that there are no modules involved, and no `.mod` files will appear).
 What is the result when you try to run the program?
 
 Try adding the appropriate `external` declaration
-```
+```fortran
   integer, external :: array_size
 ```
 What happens if you try to run the program now?
@@ -93,7 +93,7 @@ different arguments which cannot be prescribed in advance.
 
 This can be done if an interface block is provided which describes
 the function that is the dummy argument. E.g.,
-```
+```fortran
   subroutine my_integral(a, b, afunc, result)
     real, intent(in) :: a
     real, intent(in) :: b
@@ -120,7 +120,7 @@ However, it is not possible in Fortran to define two procedures of the same
 name, but different arguments (at least in the same scope). We need different
 names; suppose we have two module sub-programs, schematically:
 
-```
+```fortran
    subroutine my_specific_int(ia)
      integer, intent(inout) :: ia
      ... integer implementation ...
@@ -133,7 +133,7 @@ names; suppose we have two module sub-programs, schematically:
 ```
 A mechanism exists to allow the compiler to identify the correct routine
 based on the actual argument when used with a _generic name_. This is:
-```
+```fortran
   interface my_generic_name
     module procedure my_specific_int
     module procedure my_specific_real
@@ -160,7 +160,7 @@ correctly.
 
 For simple derived types it may be meaningful to define relational
 and arithmetic operators. For example, if we had a date type such as
-```
+```fortran
   type :: my_date
     integer :: day
     integer :: month
@@ -171,7 +171,7 @@ it may be meaningful to ask whether two dates are equal and so on (it would
 not really be meaningful to add one date to another).
 
 One can write a function to do this:
-```
+```fortran
   function my_dates_equal(date1, date2) result(equal)
     type (my_date), intent(in) :: date1
     type (my_date), intent(in) :: date2
@@ -181,9 +181,9 @@ One can write a function to do this:
 ```
 As a syntactic convenience, it might be useful to use `==` in a logical
 expression using dates. This can be arranged via
-```
+```fortran
   interface operator(==)
-    module proceduce my_dates_equal
+    module procedure my_dates_equal
   end interface
 ```
 Again this should appear in the relevant specification part of the
@@ -203,7 +203,7 @@ is declared in terms of a scalar dummy argument, but then may be
 applied to an array actual argument element by element.
 
 Such a procedure should be declared:
-```
+```fortran
   elemental function my_function(a) result(b)
     integer, intent(in) :: a
     integer             :: b
@@ -211,7 +211,7 @@ Such a procedure should be declared:
   end function my_function
 ```
 An invocation should be, e.g.:
-```
+```fortran
    iresult(1:4) = my_function(ival(1:4))
 ```
 
@@ -232,16 +232,16 @@ Write a module/program to perform a very simple numerical integration
 of a simple one-dimensional function _f(x)_. We can use a
 trapezoidal rule: for lower and upper limits _a_ and _b_, the
 integral can be approximated by
-```
+```fortran
   (b - a)*(f(a) + f(b))/2.0
 ```
 If we introduce a small interval `h = (b - a)/n` then the same
 expression is
-```
+```fortran
   h*(f(a) + sum + f(b))/2.0
 ```
 with the sum
-```
+```fortran
   sum = 0.0
   do k = 1, n-1
     sum = sum + 2.0*f(a+k*h)

--- a/section6.02/README.md
+++ b/section6.02/README.md
@@ -12,14 +12,14 @@ or simply wish to know the executable name at run time, the command line
 can be retrieved.
 
 The number of command line arguments is returned by the function
-```
+```fortran
 command_argument_count()
 ```
 This returns an `integer`: zero if the information is not available,
 or the number of arguments _not including_ the executable name itself.
 
 The entire command line can be retrieved as a string via
-```
+```fortran
   call get_command(command = cmd, length = len, status = stat)
 ```
 This returns the command line as a string (truncated or padded with spaces
@@ -29,7 +29,7 @@ All the arguments are optional.
 
 Individual command line arguments based on their position can be retrieved
 using the subroutine
-```
+```fortran
   subroutine get_command_argument(position, value, length, status)
     integer,                       intent(in)  :: position
     character (len = *), optional, intent(out) :: value
@@ -44,7 +44,7 @@ the length of the command, and `istat` returns 0 on success, -ve if the
 ### Environment variables
 
 A similar routine exists for inquiry about environment variables
-```
+```fortran
 subroutine get_environment_varaible(name, value, length, status, trim_name)
   character (len = *),           intent(in)  :: name
   character (len = *), optional, intent(out) :: value
@@ -62,7 +62,7 @@ but is too long to fit in the string provided.
 
 It is sometimes useful to pass control of execution back to the operating
 system so that some other command can be used.
-```
+```fortran
 subroutine execute_command_line(command, wait, iexit, icmd, cmdmsg)
 
   character (len = *),           intent(in)    :: command
@@ -87,7 +87,7 @@ use system commands with extreme caution, or not at all.
 ### Time and date from `date_and_time()`
 
 Use, e.g.,
-```
+```fortran
   character (len = 8)   :: date        ! "yyyymmdd"
   character (len = 10)  :: time        ! "hhmmss.sss"
   character (len = 5)   :: zone        ! "shhmm"
@@ -112,7 +112,7 @@ If you want to record the time taken to execute a particular section
 of code, the `cpu_time()` function can be used. This returns a
 `real` positive value which is some system-dependnent time in seconds.
 Subtracting two consecutive values will give and elapsed time:
-```
+```fortran
    real :: t0, t1
 
    call cpu_time(t0)

--- a/section6.03/README.md
+++ b/section6.03/README.md
@@ -21,7 +21,7 @@ implementing your own version - it's not too difficult.)
 The second step is to compute a scalar residual from a vector
 residual. If we have an array (vector) `r(1:n)` this can be
 done with:
-```
+```fortran
   residual = sum(r(:)*r(:))
 ```
 

--- a/section6.03/README.md
+++ b/section6.03/README.md
@@ -83,7 +83,7 @@ If you look at the fist few line of this example, you should see
 and provide a procedure which initialises such a type from a
 file.
 
-* Provide a procedure which brings into exsitance a dense matrix
+* Provide a procedure which brings into existence a dense matrix
 (just a two-dimensional array) initialised with the correct non-zero
 elements.
 
@@ -95,4 +95,4 @@ elements to provide a check the file has been read correctly.
 
 ## Solutions
 
-Some solutions are available in the [soultions](./solutions) directory.
+Some solutions are available in the [solutions](./solutions) directory.

--- a/section7.01/README.md
+++ b/section7.01/README.md
@@ -3,7 +3,7 @@
 ## Not covered in this course
 
 The Fortran standard covers a large and increasing number of features.
-Some of these we have only tocuhed on, and others not mentioned at all.
+Some of these we have only touched on, and others not mentioned at all.
 
 * Object-oriented features: type extension, abstract classes/interfaces, ...
 * Interoperability with C
@@ -43,7 +43,7 @@ As the Fortran preprocessor is not standardised, some care may be
 required to ensure portability. For example, stringification of
 macro arguments can be problematic.
 
-An additional compiler flag may be required to switch on the preprossor
+An additional compiler flag may be required to switch on the preprocessor
 explicitly. Alternatively, it is common that compilers will automatically
 run the preprocessor if the file extension has a capital letter e.g.,
 `.F90`, `.F03`, and so on.
@@ -105,7 +105,7 @@ in the most recent standards.
 
 In particular, the use of array sections as the `buf` argument might prove
 problematic and should probably be avoided. It is also preferable for the
-application to marshall data into a contguous buffer for performance
+application to marshal data into a contiguous buffer for performance
 reasons.
 
 In modern versions, the error return code in Fortran are optional integer
@@ -145,7 +145,7 @@ compilation directives.
 The GPU programming model of choice for Fortran has probably been
 OpenACC to the present time.
 
-NVIDIA support an Fortran extension CUDA Fortran, which is not
+NVIDIA support a Fortran extension CUDA Fortran, which is not
 portable.
 
 The OpenMP standard also has support for GPU offload, but the status
@@ -155,7 +155,7 @@ of compiler implementations is in flux.
 ## Testing
 
 Testing is an important consideration in modern software
-enginerring. A number of unit test frameworks exist:
+engineering. A number of unit test frameworks exist:
 
 * pFUnit https://github.com/Goddard-Fortran-Ecosystem/pFUnit
 

--- a/section7.01/README.md
+++ b/section7.01/README.md
@@ -33,7 +33,7 @@ C-preprocessor is part of the C standard.
 
 However, it is very common to see preprocessor directives for
 conditional compilation, and other preprocessor features. E.g.,
-```
+```c
 #ifdef HAVE_SOME_FEATURE
   ...
 #endif
@@ -70,19 +70,19 @@ distributed memory computing.
 MPI makes use of a number of data types, macro definitions, and
 library subroutines. A modern program might introduce the information
 required via
-```
+```fortran
   use mpi_f08
 ```
 which uses derived types for data types (which are often opaque).
 
 Earlier versions might use
-```
+```fortran
   use mpi
 ```
 where the opaque types are integer handles.
 
 Older codes may even use
-```
+```fortran
 #include 'mpif.h'
 ```
 to make the necessary handles and macros available.
@@ -92,7 +92,7 @@ to make the necessary handles and macros available.
 
 MPI is at base a C interface which accommodates Fortran. The C routines
 often have prototypes of the form:
-```
+```c
   int MPI_Send(const void * buf, int ount, MPI_Datatype dt, int dest, int tag,
                MPI_Comm comm);
 ```
@@ -116,7 +116,7 @@ arguments.
 
 OpenMP is a standard way to introduce thread-level parallelism
 (typically at the level of loops). A program should
-```
+```fortran
   use omp_lib
 ```
 to provide OpenMP functions and kind type parameters.
@@ -125,7 +125,7 @@ OpenMP is largely based around compiler directives, which are switched on
 via a compiler option, usually `-fopenmp`.
 
 In Fortran, the directives are introduced by the _sentinels_:
-```
+```fortran
   !$omp ...
   ...
   !$omp end ...


### PR DESCRIPTION
Pretty much as in the title.

Note that I have omitted adding syntax highlighting to blocks which are "formal" definitions of syntax which usually feature "[...]" sections to indicate optional elements.
