### PR TITLE
typo in section2.02 # Lower and upper bounds

### DIFF
--- a/section2.02/README.md
+++ b/section2.02/README.md
@@ -21,7 +21,7 @@ The default _lower bound_ is 1 and the _upper bound_ is 3.
 
 ### Lower and upper bounds
 ```
-  real, dimension(-2:1) :: b ! elements b(-2), b(1), b(0), b(1)
+  real, dimension(-2:1) :: b ! elements b(-2), b(-1), b(0), b(1)
 ```
 Here we specify, explicitly, the lower and upper bounds. The
 _size_ of this array is 4.


### PR DESCRIPTION
For the example `real, dimension(-2:1) :: b`, lower bound is -2 and upper bound is 1, thus elements should be b(-2), b(-1), b(0), b(1).